### PR TITLE
fix(ml_replicate): Getting a replication algorithm now guarantee to w…

### DIFF
--- a/R/ml_replicate.R
+++ b/R/ml_replicate.R
@@ -36,6 +36,10 @@ ml_replicate <- function(ml_fit, algorithm = c("pp", "trs", "round"), verbose = 
   .patch_verbose()
 
   algorithm <- match.arg(algorithm)
+  fun.name <- sprintf("int_%s", algorithm)
+  if (!exists(fun.name)) {
+    stop("Unknown algorithm:", algorithm)
+  }
 
   message("Replicate using '", algorithm, "' algorithm")
   group_id <- ml_fit$flat$ml_problem$fieldNames$groupId
@@ -50,7 +54,7 @@ ml_replicate <- function(ml_fit, algorithm = c("pp", "trs", "round"), verbose = 
     ml_fit$flat_weights
 
   message("Integerising the fitted weights")
-  integerised_weights <- .get_int_fnc(algorithm)(weights = weights)
+  integerised_weights <- get(fun.name)(weights = weights)
 
   message("Duplicating the reference sample")
   ind_integerised_weights <-
@@ -97,12 +101,6 @@ ml_replicate <- function(ml_fit, algorithm = c("pp", "trs", "round"), verbose = 
   message("Done!")
   tmp_cols <- grepl("^\\.\\.(.*)\\.\\.$", names(replicated_ref_sample))
   replicated_ref_sample[, !tmp_cols]
-}
-
-.get_int_fnc <- function(algorithm) {
-  getFromNamespace(sprintf("int_%s", algorithm),
-    envir = as.environment("package:mlfit")
-  )
 }
 
 int_trs <- function(weights) {

--- a/tests/testthat/test-replicate.R
+++ b/tests/testthat/test-replicate.R
@@ -30,9 +30,3 @@ test_that("integerisation methods", {
   expect_length(int_round(w), 4)
   expect_gte(sum(int_round(w)), w_rounded_sum)
 })
-
-test_that(".get_int_fnc works", {
-  int_trs <- "global_env"
-  expect_error(.get_int_fnc("not_exist"), regexp = "object \'int_not_exist\' not found")
-  expect_true(is.function(.get_int_fnc("trs")))
-})


### PR DESCRIPTION
…ork even without the mlfit package in the current environment. This can be an fatal issue when mlfit is internally called by another package. The root cause of this is in the `.get_int_fnc()` that uses `as.environment("package:mlfit")`.