### PR TITLE
refactor: removed the use of .data in tidyselect expressions as it wa…

### DIFF
--- a/R/flatten_ml_fit_problem.R
+++ b/R/flatten_ml_fit_problem.R
@@ -76,7 +76,7 @@ flatten_ml_fit_problem <- function(ml_problem,
     mutate(canonical = match(.data$gid, .data$gid)) %>%
     mutate(proxy = !duplicated(.data$canonical)) %>%
     mutate(gidx = cumsum(.data$proxy)[.data$canonical]) %>%
-    select(-.data$canonical)
+    select(-canonical)
 
   message("Splitting (2)")
   gid_lookup <-


### PR DESCRIPTION
…s deprecated in tidyselect 1.2.0.